### PR TITLE
fix: potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/internal/presentation/handler/list_handler.go
+++ b/internal/presentation/handler/list_handler.go
@@ -25,8 +25,8 @@ func NewListHandler(lister abstraction.Lister) *ListHandler {
 // HandleList handles GET /list/:pubKey requests.
 func (h *ListHandler) HandleList(c echo.Context) error {
 	pubKey := c.Param(presentation.PK)
-	if pubKey == "" {
-		c.Response().Header().Set(presentation.ReasonTag, "missing pubKey")
+	if pubKey == "" || !isValidPubKey(pubKey) {
+		c.Response().Header().Set(presentation.ReasonTag, "invalid or missing pubKey")
 
 		return c.NoContent(http.StatusBadRequest)
 	}
@@ -70,4 +70,10 @@ func parseTimeQueryParam(c echo.Context, paramName string) (*time.Time, error) {
 	t := time.Unix(ts, 0)
 
 	return &t, nil
+}
+
+// isValidPubKey validates the pubKey to ensure it is alphanumeric and meets expected length constraints.
+func isValidPubKey(pubKey string) bool {
+	const pubKeyPattern = `^[a-zA-Z0-9]{1,64}$` // Example: Adjust length as needed
+	return regexp.MustCompile(pubKeyPattern).MatchString(pubKey)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/nos3/security/code-scanning/4](https://github.com/dezh-tech/nos3/security/code-scanning/4)

To fix this issue, the `author` parameter must be validated and sanitized before being used in the MongoDB query. Since `author` is derived from `pubKey`, we need to enforce constraints on `pubKey` to ensure it adheres to expected formats (e.g., a valid public key or identifier). This can be done by introducing a validation step in the `HandleList` function in `internal/presentation/handler/list_handler.go` to sanitize the `pubKey` parameter before passing it downstream.

Additionally, we should ensure that the MongoDB query does not allow injection-like payloads by strictly treating `author` as a string and rejecting invalid formats.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
